### PR TITLE
Manual: Fixes Valgrind's doc output in overview

### DIFF
--- a/doc/manual/overview.xml
+++ b/doc/manual/overview.xml
@@ -26,7 +26,7 @@ consisting of only one logical machine named
     { config, pkgs, ... }:
     { services.httpd.enable = true;
       services.httpd.adminAddr = "alice@example.org";
-      services.httpd.documentRoot = "${pkgs.valgrind}/share/doc/valgrind/html";
+      services.httpd.documentRoot = "${pkgs.valgrind.doc}/share/doc/valgrind/html";
       networking.firewall.allowedTCPPorts = [ 80 ];
     };
 }
@@ -275,7 +275,7 @@ let
     { config, pkgs, ... }:
     { services.httpd.enable = true;
       services.httpd.adminAddr = "alice@example.org";
-      services.httpd.documentRoot = "${pkgs.valgrind}/share/doc/valgrind/html";
+      services.httpd.documentRoot = "${pkgs.valgrind.doc}/share/doc/valgrind/html";
     };
 
 in


### PR DESCRIPTION
A new `doc` output was created for Nixpkgs' Valgrind package in [4e41b64511bfa075aaba20f27f6adb75548403f0](https://github.com/NixOS/nixpkgs/commit/4e41b64511bfa075aaba20f27f6adb75548403f0). It broke the examples in NixOps's overview.
